### PR TITLE
 Personal Info Fields 

### DIFF
--- a/electron-app/src/components/Settings.tsx
+++ b/electron-app/src/components/Settings.tsx
@@ -2,42 +2,27 @@ import React from 'react';
 
 interface SettingsProps {
   apiKey: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  hobbies: string;
+  about: string;
   isApiKeyVisible: boolean;
   message: { type: 'success' | 'error'; text: string; } | null;
   onApiKeyChange: (key: string) => void;
-  onFirstNameChange: (firstName: string) => void;
-  onLastNameChange: (lastName: string) => void;
-  onEmailChange: (email: string) => void;
-  onHobbiesChange: (hobbies: string) => void;
+  onAboutChange: (about: string) => void;
   onToggleApiKeyVisibility: () => void;
 }
 
 export const Settings: React.FC<SettingsProps> = ({
   apiKey,
-  firstName,
-  lastName,
-  email,
-  hobbies,
+  about,
   isApiKeyVisible,
   message,
   onApiKeyChange,
-  onFirstNameChange,
-  onLastNameChange,
-  onEmailChange,
-  onHobbiesChange,
+  onAboutChange,
   onToggleApiKeyVisibility,
 }) => {
   const handleSaveSettings = () => {
     const data = {
       apiKey,
-      firstName,
-      lastName,
-      email,
-      hobbies,
+      about,
     };
 
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -74,42 +59,11 @@ export const Settings: React.FC<SettingsProps> = ({
       </div>
       
       <div className="form-group">
-        <label>First Name</label>
-        <input
-          type="text"
-          value={firstName}
-          onChange={(e) => onFirstNameChange(e.target.value)}
-          placeholder="Enter your first name"
-        />
-      </div>
-      
-      <div className="form-group">
-        <label>Last Name</label>
-        <input
-          type="text"
-          value={lastName}
-          onChange={(e) => onLastNameChange(e.target.value)}
-          placeholder="Enter your last name"
-        />
-      </div>
-      
-      <div className="form-group">
-        <label>Email</label>
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => onEmailChange(e.target.value)}
-          placeholder="Enter your email"
-        />
-      </div>
-      
-      <div className="form-group">
-        <label>Hobbies</label>
-        <input
-          type="text"
-          value={hobbies}
-          onChange={(e) => onHobbiesChange(e.target.value)}
-          placeholder="Enter your hobbies"
+        <label>Tell us more about yourself</label>
+        <textarea
+          value={about}
+          onChange={(e) => onAboutChange(e.target.value)}
+          placeholder="Share some details about your interests, background, or anything you'd like us to know..."
         />
       </div>
       

--- a/electron-app/src/components/Settings.tsx
+++ b/electron-app/src/components/Settings.tsx
@@ -2,24 +2,58 @@ import React from 'react';
 
 interface SettingsProps {
   apiKey: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  hobbies: string;
   isApiKeyVisible: boolean;
   message: { type: 'success' | 'error'; text: string; } | null;
   onApiKeyChange: (key: string) => void;
+  onFirstNameChange: (firstName: string) => void;
+  onLastNameChange: (lastName: string) => void;
+  onEmailChange: (email: string) => void;
+  onHobbiesChange: (hobbies: string) => void;
   onToggleApiKeyVisibility: () => void;
-  onSaveApiKey: () => void;
 }
 
 export const Settings: React.FC<SettingsProps> = ({
   apiKey,
+  firstName,
+  lastName,
+  email,
+  hobbies,
   isApiKeyVisible,
   message,
   onApiKeyChange,
+  onFirstNameChange,
+  onLastNameChange,
+  onEmailChange,
+  onHobbiesChange,
   onToggleApiKeyVisibility,
-  onSaveApiKey
 }) => {
+  const handleSaveSettings = () => {
+    const data = {
+      apiKey,
+      firstName,
+      lastName,
+      email,
+      hobbies,
+    };
+
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'settings.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   return (
     <div className="card">
       <h2>Settings</h2>
+      
       <div className="form-group">
         <label>OpenAI API Key</label>
         <div className="input-group">
@@ -37,15 +71,57 @@ export const Settings: React.FC<SettingsProps> = ({
             <span className="eye-icon">{isApiKeyVisible ? '👁️' : '👁️‍🗨️'}</span>
           </button>
         </div>
-        <button className="primary-button" onClick={onSaveApiKey}>
-          Save API Key
-        </button>
-        {message && (
-          <div className={`message ${message.type}`}>
-            {message.text}
-          </div>
-        )}
       </div>
+      
+      <div className="form-group">
+        <label>First Name</label>
+        <input
+          type="text"
+          value={firstName}
+          onChange={(e) => onFirstNameChange(e.target.value)}
+          placeholder="Enter your first name"
+        />
+      </div>
+      
+      <div className="form-group">
+        <label>Last Name</label>
+        <input
+          type="text"
+          value={lastName}
+          onChange={(e) => onLastNameChange(e.target.value)}
+          placeholder="Enter your last name"
+        />
+      </div>
+      
+      <div className="form-group">
+        <label>Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => onEmailChange(e.target.value)}
+          placeholder="Enter your email"
+        />
+      </div>
+      
+      <div className="form-group">
+        <label>Hobbies</label>
+        <input
+          type="text"
+          value={hobbies}
+          onChange={(e) => onHobbiesChange(e.target.value)}
+          placeholder="Enter your hobbies"
+        />
+      </div>
+      
+      <button className="primary-button" onClick={handleSaveSettings}>
+        Save Settings
+      </button>
+      
+      {message && (
+        <div className={`message ${message.type}`}>
+          {message.text}
+        </div>
+      )}
     </div>
   );
 };

--- a/electron-app/src/components/Settings.tsx
+++ b/electron-app/src/components/Settings.tsx
@@ -8,6 +8,7 @@ interface SettingsProps {
   onApiKeyChange: (key: string) => void;
   onAboutChange: (about: string) => void;
   onToggleApiKeyVisibility: () => void;
+  onSaveApiKey: () => void;
 }
 
 export const Settings: React.FC<SettingsProps> = ({
@@ -18,23 +19,8 @@ export const Settings: React.FC<SettingsProps> = ({
   onApiKeyChange,
   onAboutChange,
   onToggleApiKeyVisibility,
+  onSaveApiKey
 }) => {
-  const handleSaveSettings = () => {
-    const data = {
-      apiKey,
-      about,
-    };
-
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'settings.json';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
-
   return (
     <div className="card">
       <h2>Settings</h2>
@@ -63,12 +49,12 @@ export const Settings: React.FC<SettingsProps> = ({
         <textarea
           value={about}
           onChange={(e) => onAboutChange(e.target.value)}
-          placeholder="Share some details about your interests, background, or anything you'd like us to know..."
+          placeholder="Enter your profile details..."
         />
       </div>
       
-      <button className="primary-button" onClick={handleSaveSettings}>
-        Save Settings
+      <button className="primary-button" onClick={onSaveApiKey}>
+        Save API Key
       </button>
       
       {message && (


### PR DESCRIPTION
# Purpose of PR

This pull request enhances the existing Settings component by extending its functionality. The primary goal is to collect additional user information—such as first name, last name, email, and hobbies—in addition to the OpenAI API key. It also introduces a local save functionality, allowing users to download their settings as a JSON file.

# What Was Changed

- **Additional Input Fields:**
  - Added new fields for **First Name**, **Last Name**, **Email**, and **Hobbies**.
  
- **Local Save Functionality:**
  - Replaced the "Save API Key" button with a "Save Settings" button.
  - Implemented a `handleSaveSettings` function that aggregates all form data and triggers a download of a `settings.json` file containing the user's inputs.